### PR TITLE
Adding a few references.

### DIFF
--- a/avx512-quicksort/input_data.cpp
+++ b/avx512-quicksort/input_data.cpp
@@ -56,6 +56,17 @@ public:
     }
 };
 
+class InputRandomFew: public InputData {
+
+    using super = InputData;
+
+public:
+    InputRandomFew(size_t count) : super(count) {
+        for (size_t i=0; i < n; i++) {
+            array[i] = random() % 10;
+        }
+    }
+};
 
 class InputRandom: public InputData {
 

--- a/avx512-quicksort/speed.cpp
+++ b/avx512-quicksort/speed.cpp
@@ -59,6 +59,7 @@ public:
 
 
 enum class InputType {
+    randomfew,
     random,
     ascending,
     descending,
@@ -67,6 +68,9 @@ enum class InputType {
 
 const char* as_string(InputType type) {
     switch (type) {
+        case InputType::randomfew:
+            return "randomfew";
+
         case InputType::random:
             return "random";
 
@@ -121,6 +125,10 @@ public:
         , iterations(iterations) {
 
         switch (type) {
+            case InputType::randomfew:
+                data.reset(new InputRandomFew(count));
+                break;
+
             case InputType::random:
                 data.reset(new InputRandom(count));
                 break;
@@ -187,6 +195,7 @@ void usage() {
     puts("                 ascending (or asc)");
     puts("                 descending (or dsc, desc)");
     puts("                 random (or rnd, rand)");
+    puts("                 randomfew");
 }
 
 
@@ -206,8 +215,8 @@ int main(int argc, char* argv[]) {
         type = InputType::descending;
     } else if (is_keyword("ascending") || is_keyword("asc")) {
         type = InputType::ascending;
-    } else if (is_keyword("random") || is_keyword("rand") || is_keyword("rnd")) {
-        type = InputType::random;
+    } else if (is_keyword("randomfew")) {
+        type = InputType::randomfew;
     } else {
         usage();
         return EXIT_FAILURE;

--- a/avx512-quicksort/speed.cpp
+++ b/avx512-quicksort/speed.cpp
@@ -81,6 +81,25 @@ const char* as_string(InputType type) {
     }
 }
 
+void std_qsort_wrapper(uint32_t* array, int left, int right) {
+    
+    std::qsort(array + left, right - left + 1, sizeof(uint32_t),  [](const void* a, const void* b)
+    {
+        uint32_t a1 = *static_cast<const uint32_t*>(a);
+        uint32_t a2 = *static_cast<const uint32_t*>(b);
+ 
+        if(a1 < a2) return -1;
+        if(a1 > a2) return 1;
+        return 0;
+    });
+}
+
+void std_stable_sort_wrapper(uint32_t* array, int left, int right) {
+    
+    std::stable_sort(array + left, array + right + 1);
+}
+
+
 
 void std_sort_wrapper(uint32_t* array, int left, int right) {
     
@@ -122,6 +141,8 @@ public:
 
         uint32_t ref = 0;
         ref = measure("std::sort",              std_sort_wrapper,             ref);
+        measure("std::qsort",                   std_qsort_wrapper,            ref);
+        measure("std::stable_sort",             std_stable_sort_wrapper,      ref);
         measure("quick sort",                   quicksort,                    ref);
 #ifdef HAVE_AVX2_INSTRUCTIONS
         measure("AVX2 quick sort",              qs::avx2::quicksort,          ref);


### PR DESCRIPTION
Note that ``std::sort`` may not be implemented using quicksort since it has big-O requirements  in C++11 that quicksort cannot meet.

You can call that C-like ``qsort`` but it is slow for other reasons.