### PR TITLE
Add AVX2 int8 summation (maddubs variant)

### DIFF
--- a/sse-sumbytes/int8_t/Makefile
+++ b/sse-sumbytes/int8_t/Makefile
@@ -14,8 +14,9 @@ OBJ_AVX2=scalar_avx2.o\
          sse_avx2.o\
          sse_sadbw_avx2.o\
          avx2.o\
-         avx2_sadbw.o
- 
+         avx2_sadbw.o\
+         avx2_maddubs.o
+
 EXE=unittest benchmark
 EXE_AVX2=unittest_avx2 benchmark_avx2
 
@@ -27,10 +28,10 @@ sse: $(EXE)
 
 avx2: $(EXE_AVX2)
 
-unittest: unittest.cpp $(OBJ) 
+unittest: unittest.cpp $(OBJ)
 	$(CXX) $(FLAGS) $^ -o $@
 
-benchmark: benchmark.cpp $(OBJ) 
+benchmark: benchmark.cpp $(OBJ)
 	$(CXX) $(FLAGS) $^ -o $@
 
 unittest_avx2: unittest.cpp $(OBJ_AVX2)
@@ -56,6 +57,9 @@ avx2.o: avx2.cpp avx2.h
 	$(CXX) $(FLAGS_AVX2) -c $< -o $@
 
 avx2_sadbw.o: avx2_sadbw.cpp avx2_sadbw.h
+	$(CXX) $(FLAGS_AVX2) -c $< -o $@
+
+avx2_maddubs.o: avx2_maddubs.cpp avx2_maddubs.h
 	$(CXX) $(FLAGS_AVX2) -c $< -o $@
 
 scalar_avx2.o: scalar.cpp scalar.h

--- a/sse-sumbytes/int8_t/all.h
+++ b/sse-sumbytes/int8_t/all.h
@@ -7,4 +7,5 @@
 #ifdef HAVE_AVX2
 #include "avx2.h"
 #include "avx2_sadbw.h"
+#include "avx2_maddubs.h"
 #endif

--- a/sse-sumbytes/int8_t/avx2_maddubs.cpp
+++ b/sse-sumbytes/int8_t/avx2_maddubs.cpp
@@ -1,0 +1,41 @@
+#include "avx2_maddubs.h"
+
+#include <immintrin.h>
+
+int32_t avx2_maddubs_sumsignedbytes(int8_t* array, size_t size) {
+
+    const __m256i zero   = _mm256_setzero_si256();
+    const __m256i one_8  = _mm256_set1_epi8(1);
+    const __m256i one_16 = _mm256_set1_epi16(1);
+    __m256i accumulator = zero;
+
+    for (size_t j = size / (32 * 128); j != 0; --j) {
+        __m256i local_accumulator = zero;
+        for (size_t i = 0; i < 128 * 32; i += 32) {
+            const __m256i v   = _mm256_loadu_si256((__m256i*)(array + i));
+            const __m256i t0 = _mm256_maddubs_epi16(one_8, v);
+            local_accumulator = _mm256_add_epi16(local_accumulator, t0);
+        }
+        const __m256i t1 = _mm256_madd_epi16(one_16, local_accumulator);
+        accumulator = _mm256_add_epi32(accumulator, t1);
+        array += 128 * 32;
+    }
+    size_t remainder = size - ((size / (32 * 128)) * (32 * 128));
+    if (remainder) {
+        __m256i local_accumulator = zero;
+        for (size_t i = 0; i < remainder; i += 32) {
+            const __m256i v   = _mm256_loadu_si256((__m256i*)(array + i));
+            const __m256i t0 = _mm256_maddubs_epi16(one_8, v);
+            local_accumulator = _mm256_add_epi16(local_accumulator, t0);
+        }
+        const __m256i t1 = _mm256_madd_epi16(one_16, local_accumulator);
+        accumulator = _mm256_add_epi32(accumulator, t1);
+    }
+
+    const __m128i accumulator128 = _mm_add_epi32(_mm256_extracti128_si256(accumulator, 0), _mm256_extracti128_si256(accumulator, 1));
+
+    return int32_t(_mm_extract_epi32(accumulator128, 0)) +
+           int32_t(_mm_extract_epi32(accumulator128, 1)) +
+           int32_t(_mm_extract_epi32(accumulator128, 2)) +
+           int32_t(_mm_extract_epi32(accumulator128, 3));
+}

--- a/sse-sumbytes/int8_t/avx2_maddubs.h
+++ b/sse-sumbytes/int8_t/avx2_maddubs.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+
+int32_t avx2_maddubs_sumsignedbytes(int8_t* array, size_t size);

--- a/sse-sumbytes/int8_t/avx2_sadbw.h
+++ b/sse-sumbytes/int8_t/avx2_sadbw.h
@@ -5,3 +5,5 @@
 
 int32_t avx2_sadbw_sumsignedbytes(int8_t* array, size_t size);
 int32_t avx2_sadbw_unrolled4_sumsignedbytes(int8_t* array, size_t size);
+
+int32_t avx2_sadbw_variant_sumsignedbytes(int8_t* array, size_t size);

--- a/sse-sumbytes/int8_t/benchmark.cpp
+++ b/sse-sumbytes/int8_t/benchmark.cpp
@@ -5,7 +5,7 @@
 #include "all.h"
 
 class Benchmark {
-    
+
     std::vector<int8_t> input;
     size_t result;
 
@@ -25,6 +25,7 @@ public:
         test("AVX2 (v2)",                avx2_sumsignedbytes_variant2);
         test("AVX2 (sadbw)",             avx2_sadbw_sumsignedbytes);
         test("AVX2 (sadbw, unrolled)",   avx2_sadbw_unrolled4_sumsignedbytes);
+        test("AVX2 (maddubs)",           avx2_maddubs_sumsignedbytes);
 #endif
     }
 

--- a/sse-sumbytes/int8_t/benchmark.cpp
+++ b/sse-sumbytes/int8_t/benchmark.cpp
@@ -25,6 +25,7 @@ public:
         test("AVX2 (v2)",                avx2_sumsignedbytes_variant2);
         test("AVX2 (sadbw)",             avx2_sadbw_sumsignedbytes);
         test("AVX2 (sadbw, unrolled)",   avx2_sadbw_unrolled4_sumsignedbytes);
+        test("AVX2 (sadbw, variant)",    avx2_sadbw_variant_sumsignedbytes);
         test("AVX2 (maddubs)",           avx2_maddubs_sumsignedbytes);
 #endif
     }

--- a/sse-sumbytes/int8_t/unittest.cpp
+++ b/sse-sumbytes/int8_t/unittest.cpp
@@ -42,6 +42,7 @@ private:
         test("AVX2 (v2)",                avx2_sumsignedbytes_variant2);
         test("AVX2 (sadbw)",             avx2_sadbw_sumsignedbytes);
         test("AVX2 (sadbw, unrolled)",   avx2_sadbw_unrolled4_sumsignedbytes);
+        test("AVX2 (sadbw, variant)",    avx2_sadbw_variant_sumsignedbytes);
         test("AVX2 (maddubs)",           avx2_maddubs_sumsignedbytes);
 #endif
     }

--- a/sse-sumbytes/int8_t/unittest.cpp
+++ b/sse-sumbytes/int8_t/unittest.cpp
@@ -11,7 +11,7 @@ class UnitTest {
 
 public:
     UnitTest() : failed(false) {}
-    
+
     bool run() {
 
         puts("Fill array with 0x00");
@@ -42,6 +42,7 @@ private:
         test("AVX2 (v2)",                avx2_sumsignedbytes_variant2);
         test("AVX2 (sadbw)",             avx2_sadbw_sumsignedbytes);
         test("AVX2 (sadbw, unrolled)",   avx2_sadbw_unrolled4_sumsignedbytes);
+        test("AVX2 (maddubs)",           avx2_maddubs_sumsignedbytes);
 #endif
     }
 


### PR DESCRIPTION
This variant seems much better on my Haswell CPU.
I expect it to do better as well on Skylake (given sadbw/maddubs changes in latency/throughput between the 2 architectures) but that remains to be confirmed.

Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz (Haswell)
Apple LLVM version 10.0.0 (clang-1000.11.45.5)
```
element count 4096
rdtsc_overhead set to 24
scalar                        	:     0.138 cycle/op (best)    0.162 cycle/op (avg)
scalar (C++)                  	:     0.122 cycle/op (best)    0.140 cycle/op (avg)
SSE                           	:     0.305 cycle/op (best)    0.350 cycle/op (avg)
SSE (v2)                      	:     0.305 cycle/op (best)    0.326 cycle/op (avg)
SSE (sadbw)                   	:     0.138 cycle/op (best)    0.154 cycle/op (avg)
SSE (sadbw, unrolled)         	:     0.153 cycle/op (best)    0.156 cycle/op (avg)
AVX2                          	:     0.166 cycle/op (best)    0.183 cycle/op (avg)
AVX2 (v2)                     	:     0.153 cycle/op (best)    0.159 cycle/op (avg)
AVX2 (sadbw)                  	:     0.073 cycle/op (best)    0.077 cycle/op (avg)
AVX2 (sadbw, unrolled)        	:     0.066 cycle/op (best)    0.083 cycle/op (avg)
AVX2 (maddubs)                	:     0.024 cycle/op (best)    0.032 cycle/op (avg)
element count 16384
scalar                        	:     0.124 cycle/op (best)    0.140 cycle/op (avg)
scalar (C++)                  	:     0.124 cycle/op (best)    0.142 cycle/op (avg)
SSE                           	:     0.304 cycle/op (best)    0.338 cycle/op (avg)
SSE (v2)                      	:     0.304 cycle/op (best)    0.334 cycle/op (avg)
SSE (sadbw)                   	:     0.136 cycle/op (best)    0.154 cycle/op (avg)
SSE (sadbw, unrolled)         	:     0.136 cycle/op (best)    0.144 cycle/op (avg)
AVX2                          	:     0.160 cycle/op (best)    0.175 cycle/op (avg)
AVX2 (v2)                     	:     0.152 cycle/op (best)    0.169 cycle/op (avg)
AVX2 (sadbw)                  	:     0.070 cycle/op (best)    0.075 cycle/op (avg)
AVX2 (sadbw, unrolled)        	:     0.065 cycle/op (best)    0.077 cycle/op (avg)
AVX2 (maddubs)                	:     0.023 cycle/op (best)    0.026 cycle/op (avg)
element count 32768
scalar                        	:     0.122 cycle/op (best)    0.141 cycle/op (avg)
scalar (C++)                  	:     0.122 cycle/op (best)    0.139 cycle/op (avg)
SSE                           	:     0.304 cycle/op (best)    0.340 cycle/op (avg)
SSE (v2)                      	:     0.304 cycle/op (best)    0.334 cycle/op (avg)
SSE (sadbw)                   	:     0.135 cycle/op (best)    0.178 cycle/op (avg)
SSE (sadbw, unrolled)         	:     0.136 cycle/op (best)    0.171 cycle/op (avg)
AVX2                          	:     0.160 cycle/op (best)    0.179 cycle/op (avg)
AVX2 (v2)                     	:     0.152 cycle/op (best)    0.165 cycle/op (avg)
AVX2 (sadbw)                  	:     0.070 cycle/op (best)    0.081 cycle/op (avg)
AVX2 (sadbw, unrolled)        	:     0.066 cycle/op (best)    0.072 cycle/op (avg)
AVX2 (maddubs)                	:     0.023 cycle/op (best)    0.025 cycle/op (avg)
```