### PR TITLE
Add AVX2 uint16 summation madd variant

### DIFF
--- a/sse-sumbytes/uint16_t/Makefile
+++ b/sse-sumbytes/uint16_t/Makefile
@@ -12,6 +12,7 @@ OBJ=scalar.o\
 
 OBJ_AVX2=avx2.o\
          avx2_sadbw.o\
+         avx2_madd.o\
          scalar_avx2.o\
          sse_avx2.o\
          sse_sadbw_avx2.o
@@ -30,16 +31,16 @@ avx2: $(EXE_AVX2)
 
 ################################################################################
 
-unittest: unittest.cpp $(OBJ) 
+unittest: unittest.cpp $(OBJ)
 	$(CXX) $(FLAGS) $^ -o $@
 
-benchmark: benchmark.cpp $(OBJ) 
+benchmark: benchmark.cpp $(OBJ)
 	$(CXX) $(FLAGS) $^ -o $@
 
-unittest_avx2: unittest.cpp $(OBJ_AVX2) 
+unittest_avx2: unittest.cpp $(OBJ_AVX2)
 	$(CXX) $(FLAGS_AVX2) $^ -o $@
 
-benchmark_avx2: benchmark.cpp $(OBJ_AVX2) 
+benchmark_avx2: benchmark.cpp $(OBJ_AVX2)
 	$(CXX) $(FLAGS_AVX2) $^ -o $@
 
 ################################################################################
@@ -59,6 +60,9 @@ avx2.o: avx2.cpp avx2.h
 	$(CXX) $(FLAGS_AVX2) -c $< -o $@
 
 avx2_sadbw.o: avx2_sadbw.cpp avx2_sadbw.h
+	$(CXX) $(FLAGS_AVX2) -c $< -o $@
+
+avx2_madd.o: avx2_madd.cpp avx2_madd.h
 	$(CXX) $(FLAGS_AVX2) -c $< -o $@
 
 scalar_avx2.o: scalar.cpp scalar.h

--- a/sse-sumbytes/uint16_t/all.h
+++ b/sse-sumbytes/uint16_t/all.h
@@ -7,4 +7,5 @@
 #ifdef HAVE_AVX2
 #include "avx2.h"
 #include "avx2_sadbw.h"
+#include "avx2_madd.h"
 #endif

--- a/sse-sumbytes/uint16_t/avx2_madd.cpp
+++ b/sse-sumbytes/uint16_t/avx2_madd.cpp
@@ -1,0 +1,25 @@
+#include "avx2_madd.h"
+
+#include <immintrin.h>
+
+uint32_t avx2_madd_sumwords(uint16_t* array, size_t size) {
+
+    const __m256i one    = _mm256_set1_epi16(1);
+    const __m256i addend = _mm256_set1_epi16(-32768);
+
+    __m256i accumulator = _mm256_setzero_si256();
+
+    for (size_t i=0; i < size; i += 16) {
+        const __m256i v  = _mm256_loadu_si256((__m256i*)(array + i));
+        const __m256i t0 = _mm256_xor_si256(v, addend);
+        const __m256i t1 = _mm256_madd_epi16(t0, one);
+        accumulator = _mm256_add_epi32(accumulator, t1);
+    }
+    const __m128i accumulator128 = _mm_add_epi32(_mm256_extracti128_si256(accumulator, 0), _mm256_extracti128_si256(accumulator, 1));
+
+    return uint32_t(_mm_extract_epi32(accumulator128, 0)) +
+           uint32_t(_mm_extract_epi32(accumulator128, 1)) +
+           uint32_t(_mm_extract_epi32(accumulator128, 2)) +
+           uint32_t(_mm_extract_epi32(accumulator128, 3)) +
+           32768 * uint32_t(size);
+}

--- a/sse-sumbytes/uint16_t/avx2_madd.h
+++ b/sse-sumbytes/uint16_t/avx2_madd.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+
+uint32_t avx2_madd_sumwords(uint16_t* array, size_t size);

--- a/sse-sumbytes/uint16_t/benchmark.cpp
+++ b/sse-sumbytes/uint16_t/benchmark.cpp
@@ -5,7 +5,7 @@
 #include "all.h"
 
 class Benchmark {
-    
+
     std::vector<uint16_t> input;
     size_t result;
 
@@ -27,6 +27,7 @@ public:
         test("AVX2 (sadbw)",           avx2_sadbw_sumwords);
         test("AVX2 (sadbw-v2)",        avx2_sadbw_sumwords_variant2);
         test("AVX2 (sadbw, unrolled)", avx2_sadbw_unrolled4_sumwords);
+        test("AVX2 (madd)",            avx2_madd_sumwords);
 #endif
     }
 

--- a/sse-sumbytes/uint16_t/unittest.cpp
+++ b/sse-sumbytes/uint16_t/unittest.cpp
@@ -11,7 +11,7 @@ class UnitTest {
 
 public:
     UnitTest() : failed(false) {}
-    
+
     bool run() {
 
         puts("Fill array with 0x0000");
@@ -44,6 +44,7 @@ private:
         test("AVX2 (sadbw)",           avx2_sadbw_sumwords);
         test("AVX2 (sadbw-v2)",        avx2_sadbw_sumwords_variant2);
         test("AVX2 (sadbw, unrolled)", avx2_sadbw_unrolled4_sumwords);
+        test("AVX2 (madd)",            avx2_madd_sumwords);
 #endif
     }
 


### PR DESCRIPTION
madd proves better on Haswell than the v2 (not by much) or sadbw.
I'm once again curious about how it compares on Skylake (sadbw has lower latency but madd has higher throughput)

Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz (Haswell)
Apple LLVM version 10.0.0 (clang-1000.11.45.5)
```
element count 4096
rdtsc_overhead set to 24
scalar                        	:     0.133 cycle/op (best)    0.152 cycle/op (avg)
scalar (C++)                  	:     0.123 cycle/op (best)    0.131 cycle/op (avg)
SSE                           	:     0.250 cycle/op (best)    0.258 cycle/op (avg)
SSE (v2)                      	:     0.171 cycle/op (best)    0.202 cycle/op (avg)
SSE (sadbw)                   	:     0.205 cycle/op (best)    0.231 cycle/op (avg)
SSE (sadbw, v2)               	:     0.171 cycle/op (best)    0.199 cycle/op (avg)
SSE (sadbw, unrolled)         	:     0.204 cycle/op (best)    0.235 cycle/op (avg)
AVX2                          	:     0.142 cycle/op (best)    0.189 cycle/op (avg)
AVX2 (v2)                     	:     0.089 cycle/op (best)    0.093 cycle/op (avg)
AVX2 (sadbw)                  	:     0.113 cycle/op (best)    0.120 cycle/op (avg)
AVX2 (sadbw-v2)               	:     0.092 cycle/op (best)    0.103 cycle/op (avg)
AVX2 (sadbw, unrolled)        	:     0.104 cycle/op (best)    0.118 cycle/op (avg)
AVX2 (madd)                   	:     0.081 cycle/op (best)    0.088 cycle/op (avg)
element count 16384
scalar                        	:     0.123 cycle/op (best)    0.136 cycle/op (avg)
scalar (C++)                  	:     0.122 cycle/op (best)    0.139 cycle/op (avg)
SSE                           	:     0.253 cycle/op (best)    0.287 cycle/op (avg)
SSE (v2)                      	:     0.172 cycle/op (best)    0.194 cycle/op (avg)
SSE (sadbw)                   	:     0.212 cycle/op (best)    0.220 cycle/op (avg)
SSE (sadbw, v2)               	:     0.174 cycle/op (best)    0.194 cycle/op (avg)
SSE (sadbw, unrolled)         	:     0.213 cycle/op (best)    0.234 cycle/op (avg)
AVX2                          	:     0.130 cycle/op (best)    0.183 cycle/op (avg)
AVX2 (v2)                     	:     0.085 cycle/op (best)    0.089 cycle/op (avg)
AVX2 (sadbw)                  	:     0.109 cycle/op (best)    0.114 cycle/op (avg)
AVX2 (sadbw-v2)               	:     0.093 cycle/op (best)    0.103 cycle/op (avg)
AVX2 (sadbw, unrolled)        	:     0.104 cycle/op (best)    0.112 cycle/op (avg)
AVX2 (madd)                   	:     0.079 cycle/op (best)    0.086 cycle/op (avg)
element count 32768
scalar                        	:     0.143 cycle/op (best)    0.158 cycle/op (avg)
scalar (C++)                  	:     0.143 cycle/op (best)    0.160 cycle/op (avg)
SSE                           	:     0.254 cycle/op (best)    0.277 cycle/op (avg)
SSE (v2)                      	:     0.204 cycle/op (best)    0.216 cycle/op (avg)
SSE (sadbw)                   	:     0.253 cycle/op (best)    0.268 cycle/op (avg)
SSE (sadbw, v2)               	:     0.222 cycle/op (best)    0.228 cycle/op (avg)
SSE (sadbw, unrolled)         	:     0.250 cycle/op (best)    0.265 cycle/op (avg)
AVX2                          	:     0.132 cycle/op (best)    0.202 cycle/op (avg)
AVX2 (v2)                     	:     0.102 cycle/op (best)    0.113 cycle/op (avg)
AVX2 (sadbw)                  	:     0.133 cycle/op (best)    0.142 cycle/op (avg)
AVX2 (sadbw-v2)               	:     0.120 cycle/op (best)    0.129 cycle/op (avg)
AVX2 (sadbw, unrolled)        	:     0.124 cycle/op (best)    0.141 cycle/op (avg)
AVX2 (madd)                   	:     0.085 cycle/op (best)    0.090 cycle/op (avg)
```