### PR TITLE
remove zero2 from cmp loop

### DIFF
--- a/avx512-string/avx512f-strcmp.cpp
+++ b/avx512-string/avx512f-strcmp.cpp
@@ -17,8 +17,8 @@ int avx512f_strcmp(const char* s1, const char* s2) {
     char* c2 = const_cast<char*>(s2);
 
     __mmask16 zero1;
-    __mmask16 zero2;
     __mmask16 diff;
+    __mmask16 either;
 
     while (true) {
 
@@ -27,14 +27,12 @@ int avx512f_strcmp(const char* s1, const char* s2) {
 
         // locate in s1 dwords having '\0'
         zero1 = zero_byte_mask(v1);
+	// a '\0' in v2 will trigger a diff or a 1 bit in zero1
+        diff  = _mm512_cmpneq_epi32_mask(v1, v2);
 
-        // locate in s1 dwords having '\0'
-        zero2 = zero_byte_mask(v2);
-
-        // locate differences between s1 and s2
-        diff  = _mm512_cmpneq_epi32_mask(_mm512_xor_si512(v1, v2), _mm512_setzero_si512());
-
-        if (zero1 != 0 || zero2 != 0 || diff != 0) {
+	// use lowest order 1 bit of either/both ops
+	either = zero1 | diff;
+        if (either) {
             break;
         }
 
@@ -42,79 +40,23 @@ int avx512f_strcmp(const char* s1, const char* s2) {
         c2 += 64;
     }
 
-    // get result
+    const size_t n = __builtin_ctz(either);
 
-    const uint16_t zeros = zero1 | zero2;
-
-    if (zeros == 0) {
-        
-        // no zeros within current chunk
-        const size_t n = __builtin_ctz(diff);
-
-        // move pointers to the first dword with diff
-        c1 += n * 4;
-        c2 += n * 4;
-        goto locate_diff;
-
-    } else if (diff == 0) {
-
-        // no explicit diff, but one string might be shorter
-        const size_t k = __builtin_ctz(zeros);
-        c1 += k * 4;
-        c2 += k * 4;
-        goto locate_diff_or_eos;
-
-    } else {
-
-        // there is diff and zeros
-        const size_t n = __builtin_ctz(diff);
-        const size_t k = __builtin_ctz(zeros);
-        if (n < k) {
-            // first difference is located in dword preceeding dword with zeros
-            // move pointers to that dword
-            c1 += n * 4;
-            c2 += n * 4;
-            goto locate_diff;
-        } else if (k > n) {
-            
-            // first difference is past zeros (strings are equal, but garbage after EOS differs)
-            return 0;
-        } else /* n == k */ {
-            
-             c1 += k * 4;
-             c2 += k * 4;
-             goto locate_diff_or_eos;
-        }
-    }
-
-    assert(false);
-
-locate_diff:
+    // move pointers to the first dword with diff and/or eos
+    c1 += n * 4;
+    c2 += n * 4;
     
+    // strncmp resolves which byte wins
     for (int i=0; i < 4; i++) {
         int a = c1[i];
         int b = c2[i];
-        if (a != b) {
+
+        if (a != b || !a) {
             return a - b;
         }
     }
 
     assert(false);
 
-locate_diff_or_eos:
-
-    for (int i=0; i < 4; i++) {
-        int a = c1[i];
-        int b = c2[i];
-        if (a == 0 && b == 0) {
-            return 0;
-        }
-
-        if (a != b) {
-            return a - b;
-        }
-    }
-
-    assert(false);
 }
 


### PR DESCRIPTION
String comparison only requires two comparisons, one to zero and one between strings.  The case where the other string has a zero is covered either by inequality or the first string.  

Byte-level comparison is simplified to comparison at the first diff or null.

The benchmark is about 50% faster.