### PR TITLE
Add u8div SSE and AVX2 implementations using the "cvtt" instruction

### DIFF
--- a/u8div/avx2.cpp
+++ b/u8div/avx2.cpp
@@ -35,6 +35,42 @@ void avx2_div_u8(const uint8_t* a, const uint8_t* b, uint8_t* out, size_t n) {
     }
 }
 
+void avx2_div_u8_cvtt(const uint8_t* a, const uint8_t* b, uint8_t* out, size_t n) {
+    const __m128i t0 = _mm_setr_epi8(
+        0, 4, 8, 12,
+        -1, -1, -1, -1,
+        -1, -1, -1, -1,
+        -1, -1, -1, -1
+    );
+
+    const __m256i u32_u8 = _mm256_set_m128i(t0, t0);
+
+    for (size_t i=0; i < n; i += 8) {
+        uint64_t buf_a;
+        memcpy(&buf_a, &a[i], 8);
+        const __m128i a_u8  = _mm_cvtsi64_si128(buf_a);
+        const __m256i a_u32 = _mm256_cvtepu8_epi32(a_u8);
+        const __m256  a_f32 = _mm256_cvtepi32_ps(a_u32);
+
+        uint64_t buf_b;
+        memcpy(&buf_b, &b[i], 8);
+        const __m128i b_u8  = _mm_cvtsi64_si128(buf_b);
+        const __m256i b_u32 = _mm256_cvtepu8_epi32(b_u8);
+        const __m256  b_f32 = _mm256_cvtepi32_ps(b_u32);
+
+        const __m256  c_f32   = _mm256_div_ps(a_f32, b_f32);
+        const __m256i c_i32   = _mm256_cvttps_epi32(c_f32);
+
+        const __m256i c_u8 = _mm256_shuffle_epi8(c_i32, u32_u8);
+
+        const uint64_t lo = (uint32_t)_mm256_extract_epi32(c_u8, 0);
+        const uint64_t hi = (uint32_t)_mm256_extract_epi32(c_u8, 4);
+
+        const uint64_t buf = lo | (hi << 32);
+        memcpy(&out[i], &buf, 8);
+    }
+}
+
 void avx2_div_u8_rcp(const uint8_t* a, const uint8_t* b, uint8_t* out, size_t n) {
     const __m128i t0 = _mm_setr_epi8(
         0 + 1, 4 + 1, 8 + 1, 12 + 1,

--- a/u8div/benchmark.cpp
+++ b/u8div/benchmark.cpp
@@ -24,12 +24,14 @@ int main() {
     #ifdef HAVE_SSE
         BEST_TIME(/**/, sse_div_u8(a, b, c, SIZE), "SSE", repeat, SIZE);
         BEST_TIME(/**/, sse_div_u8_no_rounding(a, b, c, SIZE), "SSE (no rounding)", repeat, SIZE);
+        BEST_TIME(/**/, sse_div_u8_cvtt(a, b, c, SIZE), "SSE (cvtt)", repeat, SIZE);
         BEST_TIME(/**/, sse_div_u8_rcp(a, b, c, SIZE), "SSE (rcp)", repeat, SIZE);
         BEST_TIME(/**/, sse_long_div_u8(a, b, c, SIZE), "SSE long div", repeat, SIZE);
     #endif
 
     #ifdef HAVE_AVX2
         BEST_TIME(/**/, avx2_div_u8(a, b, c, SIZE), "AVX2", repeat, SIZE);
+        BEST_TIME(/**/, avx2_div_u8_cvtt(a, b, c, SIZE), "AVX2 (cvtt)", repeat, SIZE);
         BEST_TIME(/**/, avx2_div_u8_rcp(a, b, c, SIZE), "AVX2 (rcp)", repeat, SIZE);
         BEST_TIME(/**/, avx2_long_div_u8(a, b, c, SIZE), "AVX2 long div", repeat, SIZE);
     #endif

--- a/u8div/sse.cpp
+++ b/u8div/sse.cpp
@@ -64,6 +64,35 @@ void sse_div_u8_no_rounding(const uint8_t* a, const uint8_t* b, uint8_t* out, si
     }
 }
 
+void sse_div_u8_cvtt(const uint8_t* a, const uint8_t* b, uint8_t* out, size_t n) {
+    for (size_t i=0; i < n; i += 4) {
+        uint32_t buf_a;
+        memcpy(&buf_a, &a[i], 4);
+        const __m128i a_u8  = _mm_cvtsi32_si128(buf_a);
+        const __m128i a_u32 = _mm_cvtepu8_epi32(a_u8);
+        const __m128  a_f32 = _mm_cvtepi32_ps(a_u32);
+
+        uint32_t buf_b;
+        memcpy(&buf_b, &b[i], 4);
+        const __m128i b_u8  = _mm_cvtsi32_si128(buf_b);
+        const __m128i b_u32 = _mm_cvtepu8_epi32(b_u8);
+        const __m128  b_f32 = _mm_cvtepi32_ps(b_u32);
+
+        const __m128  c_f32   = _mm_div_ps(a_f32, b_f32);
+        const __m128i c_i32 = _mm_cvttps_epi32(c_f32);
+
+        const __m128i c_u8  = _mm_shuffle_epi8(c_i32, _mm_setr_epi8(
+            0, 4, 8, 12,
+            -1, -1, -1, -1,
+            -1, -1, -1, -1,
+            -1, -1, -1, -1
+        ));
+
+        const uint32_t buf = _mm_cvtsi128_si32(c_u8);
+        memcpy(&out[i], &buf, 4);
+    }
+}
+
 void sse_div_u8_rcp(const uint8_t* a, const uint8_t* b, uint8_t* out, size_t n) {
     // Note: The magic constant 1.00025* was devised from rcp_test utility output.
     //       This tiny correction applied for the dividend masks RPC errors for

--- a/u8div/unittest.cpp
+++ b/u8div/unittest.cpp
@@ -35,12 +35,14 @@ public:
         #ifdef HAVE_SSE
             check("SSE", sse_div_u8);
             check("SSE (no rounding)", sse_div_u8_no_rounding);
+            check("SSE (cvtt)", sse_div_u8_cvtt);
             check("SSE (rcp)", sse_div_u8_rcp);
             check("SSE long div", sse_long_div_u8);
         #endif
 
         #ifdef HAVE_AVX2
             check("AVX2", avx2_div_u8);
+            check("AVX2 (cvtt)", avx2_div_u8_cvtt);
             check("AVX2 (rcp)", avx2_div_u8_rcp);
             check("AVX2 long div", avx2_long_div_u8);
         #endif


### PR DESCRIPTION
These versions don't benchmark quite as well as your rcp implementation, so this pull is more to show this option to you. 

(Do feel free to reject or ignore it!)