### PR TITLE
u8div: Add 4x unrolled rcp versions

### DIFF
--- a/u8div/avx512.cpp
+++ b/u8div/avx512.cpp
@@ -79,3 +79,36 @@ void avx512_div_u8_rcp(const uint8_t* A, const uint8_t* B, uint8_t* out, size_t 
         _mm_storeu_si128((__m128i*)&out[i], c_u8);
     }
 }
+
+static __m512i divlo_u8_i32x16(__m512i a, __m512i b, float mul) {
+    __m512 af = _mm512_cvtepi32_ps(a);
+    __m512 bf = _mm512_cvtepi32_ps(b);
+    __m512 m1 = _mm512_mul_ps(af, _mm512_set1_ps(1.001f * mul));
+    __m512 m2 = _mm512_rcp14_ps(bf);
+    return _mm512_cvttps_epi32(_mm512_mul_ps(m1, m2));
+}
+static __m512i div_u8x64(__m512i a, __m512i b) {
+    __m512i m0 = _mm512_set1_epi32(0x000000ff);
+    __m512i m1 = _mm512_set1_epi32(0x0000ff00);
+    __m512i m2 = _mm512_set1_epi32(0x00ff0000);
+
+    __m512i r0 = divlo_u8_i32x16(_mm512_and_si512(a, m0), _mm512_and_si512(b, m0), 1);
+    __m512i r1 = divlo_u8_i32x16(_mm512_and_si512(a, m1), _mm512_and_si512(b, m1), 1<<8);
+
+
+    __m512i r2 = divlo_u8_i32x16(_mm512_and_si512(a, m2), _mm512_and_si512(b, m2), 1<<16);
+    __m512i r3 = divlo_u8_i32x16(_mm512_srli_epi32(a, 24), _mm512_srli_epi32(b, 24), 1);
+    r3 = _mm512_slli_epi32(r3, 24);
+
+    __m512i r01 = _mm512_mask_blend_epi8(0xAAAAAAAAAAAAAAAA, r0, r1);
+    __m512i r23 = _mm512_or_si512(r2, r3);
+    return _mm512_mask_blend_epi16(0xAAAAAAAA, r01, r23);
+}
+void avx512_div_u8_rcp_4x(const uint8_t* a, const uint8_t* b, uint8_t* out, size_t n) {
+    for (size_t i=0; i < n; i += 64) {
+        __m512i av = _mm512_loadu_epi8(a+i);
+        __m512i bv = _mm512_loadu_epi8(b+i);
+        __m512i rv = div_u8x64(av, bv);
+        _mm512_storeu_epi8(out+i, rv);
+    }
+}

--- a/u8div/benchmark.cpp
+++ b/u8div/benchmark.cpp
@@ -33,12 +33,14 @@ int main() {
         BEST_TIME(/**/, avx2_div_u8(a, b, c, SIZE), "AVX2", repeat, SIZE);
         BEST_TIME(/**/, avx2_div_u8_cvtt(a, b, c, SIZE), "AVX2 (cvtt)", repeat, SIZE);
         BEST_TIME(/**/, avx2_div_u8_rcp(a, b, c, SIZE), "AVX2 (rcp)", repeat, SIZE);
+        BEST_TIME(/**/, avx2_div_u8_rcp_4x(a, b, c, SIZE), "AVX2 (4x rcp)", repeat, SIZE);
         BEST_TIME(/**/, avx2_long_div_u8(a, b, c, SIZE), "AVX2 long div", repeat, SIZE);
     #endif
 
     #ifdef HAVE_AVX512
         BEST_TIME(/**/, avx512_div_u8_cvtt(a, b, c, SIZE), "AVX512 (cvtt)", repeat, SIZE);
         BEST_TIME(/**/, avx512_div_u8_rcp(a, b, c, SIZE), "AVX512 (rcp)", repeat, SIZE);
+        BEST_TIME(/**/, avx2_div_u8_rcp_4x(a, b, c, SIZE), "AVX512 (4x rcp)", repeat, SIZE);
         BEST_TIME(/**/, avx512_long_div_u8(a, b, c, SIZE), "AVX512 long div", repeat, SIZE);
     #endif
 }

--- a/u8div/unittest.cpp
+++ b/u8div/unittest.cpp
@@ -44,12 +44,14 @@ public:
             check("AVX2", avx2_div_u8);
             check("AVX2 (cvtt)", avx2_div_u8_cvtt);
             check("AVX2 (rcp)", avx2_div_u8_rcp);
+            check("AVX2 (4x rcp)", avx2_div_u8_rcp_4x);
             check("AVX2 long div", avx2_long_div_u8);
         #endif
 
         #ifdef HAVE_AVX512
             check("AVX512 (cvtt)", avx512_div_u8_cvtt);
             check("AVX512 (rcp)", avx512_div_u8_rcp);
+            check("AVX512 (4x rcp)", avx512_div_u8_rcp_4x);
             check("AVX512 long div", avx512_long_div_u8);
         #endif
 


### PR DESCRIPTION
The 4x unrolling allows bypassing the cross-lane logic, making better use of loads/stores, plus has some fancy blending together of the results. On Haswell it measures ~1.55x faster than "AVX2 (rcp)", ending up as the fastest solution.

The AVX-512 version passes the unittests in SDE, but I haven't tested it on real hardware.

(full `benchmark_avx2` Haswell results, with `const size_t repeat = 1000;`:)

```c
scalar                        	:     8.107 cycle/op (best)    8.252 cycle/op (avg)
scalar (unrolled x 4)         	:     8.080 cycle/op (best)    8.156 cycle/op (avg)
scalar (long div)             	:    17.003 cycle/op (best)   17.920 cycle/op (avg)
scalar (long div, autovect)   	:     1.646 cycle/op (best)    1.731 cycle/op (avg)
SSE                           	:     1.803 cycle/op (best)    1.891 cycle/op (avg)
SSE (no rounding)             	:     1.786 cycle/op (best)    1.858 cycle/op (avg)
SSE (cvtt)                    	:     1.787 cycle/op (best)    1.890 cycle/op (avg)
SSE (rcp)                     	:     1.169 cycle/op (best)    1.249 cycle/op (avg)
SSE long div                  	:     2.287 cycle/op (best)    2.404 cycle/op (avg)
AVX2                          	:     1.825 cycle/op (best)    1.904 cycle/op (avg)
AVX2 (cvtt)                   	:     1.845 cycle/op (best)    1.927 cycle/op (avg)
AVX2 (rcp)                    	:     1.218 cycle/op (best)    1.300 cycle/op (avg)
AVX2 (4x rcp)                 	:     0.759 cycle/op (best)    0.829 cycle/op (avg)
AVX2 long div                 	:     1.191 cycle/op (best)    1.380 cycle/op (avg)
```